### PR TITLE
app-cdr/bchunk: Update to 1.2.2 from 1.2.0

### DIFF
--- a/packages/app-cdr/bchunk/bchunk-1.2.2.exheres-0
+++ b/packages/app-cdr/bchunk/bchunk-1.2.2.exheres-0
@@ -1,0 +1,32 @@
+# Copyright 2009 Hong Hao <oahong@gmail.com>
+# Distributed under the terms of the GNU General Public License v2
+
+SUMMARY="binchunker for Unix"
+DESCRIPTION="
+This package contains a UNIX/C rewrite of the BinChunker program.
+BinChunker converts a CD image in a .bin/.cue format (sometimes .raw/.cue)
+into a set of .iso and .cdr/.wav tracks.  The .bin/.cue format is used by
+some non-UNIX CD-writing software, but is not supported on most other
+CD-writing programs.
+"
+HOMEPAGE="http://he.fi/bchunk"
+DOWNLOADS="${HOMEPAGE}/${PNV}.tar.gz"
+
+LICENCES="GPL-2"
+SLOT="0"
+PLATFORMS="~amd64 ~x86"
+MYOPTIONS=""
+
+DEPENDENCIES=""
+
+UPSTREAM_CHANGELOG="${HOMEPAGE}/ChangeLog"
+
+DEFAULT_SRC_COMPILE_PARAMS=(
+    CC="${CC}" LD="${CC}" CFLAGS="${CFLAGS}"
+)
+
+src_install() {
+    dobin ${PN}
+    doman ${PN}.1
+}
+


### PR DESCRIPTION
* Patches are incorporated in source code, CVE patch merge explicitly confirmed, [http://he.fi/bchunk/](url)

* No differences between `${WORK}/Makefile`