### PR TITLE
librime: add slot operator for yaml-cpp

### DIFF
--- a/packages/inputmethods/librime/librime-1.2.9-r2.exheres-0
+++ b/packages/inputmethods/librime/librime-1.2.9-r2.exheres-0
@@ -1,7 +1,7 @@
 # Copyright 2017 Hong Hao <oahong@gmail.com>
 # Distributed under the terms of the GNU General Public License v2
 
-require github [ user=rime ] cmake [ api=2 ]
+require github [ user=rime ] cmake
 
 SUMMARY="Rime Input Method Engine, the core library"
 HOMEPAGE+=" https://rime.im"

--- a/packages/inputmethods/librime/librime-1.2.9-r2.exheres-0
+++ b/packages/inputmethods/librime/librime-1.2.9-r2.exheres-0
@@ -4,7 +4,7 @@
 require github [ user=rime ] cmake [ api=2 ]
 
 SUMMARY="Rime Input Method Engine, the core library"
-HOMEPAGE="http://rime.im"
+HOMEPAGE+=" https://rime.im"
 
 LICENCES="BSD-3"
 SLOT="0"

--- a/packages/inputmethods/librime/librime-1.2.9-r2.exheres-0
+++ b/packages/inputmethods/librime/librime-1.2.9-r2.exheres-0
@@ -18,7 +18,7 @@ DEPENDENCIES="
         cjk/opencc
         dev-db/leveldb
         dev-libs/marisa-trie
-        dev-libs/yaml-cpp
+        dev-libs/yaml-cpp:=
         x11-libs/libX11
     test:
         dev-cpp/gtest


### PR DESCRIPTION
The additionall two commits update HOMEPAGE and remove the now redundant api=2 from require cmake.